### PR TITLE
Resolve list of tasks due before running the tasks.

### DIFF
--- a/src/pmill/Scheduler/TaskList.php
+++ b/src/pmill/Scheduler/TaskList.php
@@ -45,6 +45,16 @@ class TaskList
     }
 
     /**
+     * @return TaskInterface[]
+     */
+    public function getTasksDue()
+    {
+        return array_filter($this->tasks, function (TaskInterface $task) {
+            return $task->isDue();
+        });
+    }
+
+    /**
      * @return array
      */
     public function getOutput()
@@ -61,16 +71,15 @@ class TaskList
     {
         $this->output = [];
 
-        foreach ($this->tasks as $task) {
-            if ($task->isDue()) {
-                $result = $task->run();
-                $this->output[] = [
-                    'task' => get_class($task),
-                    'result' => $result,
-                    'output' => $task->getOutput(),
-                ];
-            }
+        foreach ($this->getTasksDue() as $task) {
+            $result = $task->run();
+            $this->output[] = [
+                'task' => get_class($task),
+                'result' => $result,
+                'output' => $task->getOutput(),
+            ];
         }
+
         return $this->output;
     }
 }


### PR DESCRIPTION
First examine the lists of tasks for those that are due before processing the list of tasks.  This fixes an issue where the individual task execution time exceeds the time frame within which a task was due thus not running additional tasks in the list.

Example: 
100 tasks in the list, 10 tasks are due and each task takes 30 seconds to complete.  By the time the second task is complete and the 3rd task is being checked to determine if it is due there is a small chance that it may no longer qualify as being due.   If the 3rd task still qualifies as due and takes an additional 30 seconds then the 4th thru 10th task that were originally considered due are no longer considered due because of the execution time of the first three tasks cause time to elapse and close the window for the current due time of tasks 4 through 10.

